### PR TITLE
Fix API environment response to show 'staging' instead of 'development'

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", case_sensitive=False, extra="ignore")
 
     app_name: str = "FastAPI AWS App"
-    environment: str = "development"
+    environment: str = Field(default="staging", description="Deployment environment (staging, production, development)")
     debug: bool = True
     api_v1_prefix: str = "/api/v1"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from app.config import Settings, get_settings
 def test_default_settings():
     settings = Settings()
     assert settings.app_name == "FastAPI AWS App"
-    assert settings.environment == "development"
+    assert settings.environment == "staging"
     assert settings.debug is True
     assert settings.api_v1_prefix == "/api/v1"
     assert settings.aws_region == "us-east-1"


### PR DESCRIPTION
## Summary
- Updates the API root endpoint to return `"environment": "staging"` instead of `"environment": "development"`
- Changes default environment configuration from 'development' to 'staging' 
- Updates corresponding test assertions

## Changes Made
- **app/config.py**: Changed default environment value to 'staging'
- **.env**: Updated ENVIRONMENT variable to 'staging' 
- **tests/test_config.py**: Updated test to expect 'staging' instead of 'development'

## Test Plan
- [x] Config tests pass locally
- [x] Verified environment value loads as 'staging' 
- [ ] Deploy and verify API endpoint returns correct environment

## Before/After
**Before**: `{"environment": "development", ...}`
**After**: `{"environment": "staging", ...}`

🤖 Generated with [Claude Code](https://claude.ai/code)